### PR TITLE
fix(missing-dependency): Add missing react-native-material-ripple

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm i @freakycoder/react-native-button
 "react-native-vector-icons": ">= 6.x.x",
 "react-native-linear-gradient": ">= 2.5.x",
 "react-native-dynamic-vector-icons": ">= x.x.x",
-"react-native-material-ripple": "^0.9.1"
+"react-native-material-ripple": "^0.8.0"
 ```
 
 # Button Component Options

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ npm i @freakycoder/react-native-button
 "react-native-androw": "0.0.31",
 "react-native-vector-icons": ">= 6.x.x",
 "react-native-linear-gradient": ">= 2.5.x",
-"react-native-dynamic-vector-icons": ">= x.x.x"
+"react-native-dynamic-vector-icons": ">= x.x.x",
+"react-native-material-ripple": "^0.9.1"
 ```
 
 # Button Component Options

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-native-androw": "0.0.31",
     "react-native-vector-icons": ">= 6.x.x",
     "react-native-linear-gradient": ">= 2.5.x",
-    "react-native-dynamic-vector-icons": ">= x.x.x"
+    "react-native-dynamic-vector-icons": ">= x.x.x",
+    "react-native-material-ripple": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "react-native-vector-icons": ">= 6.x.x",
     "react-native-linear-gradient": ">= 2.5.x",
     "react-native-dynamic-vector-icons": ">= x.x.x",
-    "react-native-material-ripple": "^0.9.1"
+    "react-native-material-ripple": "^0.8.0"
   }
 }


### PR DESCRIPTION
Add missing react-native-material-ripple required for GooglePlayButton component.

Without it it throw the following error:
![Screenshot 2020-12-17 at 23 06 58](https://user-images.githubusercontent.com/6340490/102549837-1a597900-40bd-11eb-87b6-b82c3ac1e049.png)

~The ripple effect is not working to me btw~ *EDIT*: Was due to another library.